### PR TITLE
Refactored additional tree modification calls

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -186,17 +186,13 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             obj.numchild = 0
             obj.depth = 0
             if parent:
-                parent.add_child(instance=obj)
+                saved_obj = parent.add_child(instance=obj)
             else:
-                obj.add_root(instance=obj)
-            new_pk = obj.pk
-            saved_obj = Page.objects.get(pk=new_pk)
-            obj.pk = pk
-            obj.path = saved_obj.path
-            obj.numchild = saved_obj.numchild
-            obj.depth = saved_obj.depth
-            saved_obj.delete()
-            obj.save(no_signals=True)
+                saved_obj = obj.add_root(instance=obj)
+            tmp_pk = saved_obj.pk
+            saved_obj.pk = pk
+            Page.objects.get(pk=tmp_pk).delete()
+            saved_obj.save(no_signals=True)
         else:
             if 'history' in request.path_info:
                 old_obj = Page.objects.get(pk=obj.pk)

--- a/cms/api.py
+++ b/cms/api.py
@@ -219,8 +219,7 @@ def create_page(title, template, language, menu_title=None, slug=None,
         limit_visibility_in_menu=limit_visibility_in_menu,
         xframe_options=xframe_options,
     )
-    page.add_root(instance=page)
-    page = page.reload()
+    page = page.add_root(instance=page)
 
     if parent:
         page = page.move(target=parent, pos=position)
@@ -343,11 +342,10 @@ def add_plugin(placeholder, plugin_type, language, position='last-child',
         parent_id=parent_id,
     )
 
-    plugin_base.add_root(instance=plugin_base)
+    plugin_base = plugin_base.add_root(instance=plugin_base)
 
     if target:
-        plugin_base.move(target, pos=position)
-        plugin_base = CMSPlugin.objects.get(pk=plugin_base.pk)
+        plugin_base = plugin_base.move(target, pos=position)
     plugin = plugin_model(**data)
     plugin_base.set_base_attr(plugin)
     plugin.save()

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -1150,8 +1150,7 @@ class Page(with_metaclass(PageMetaClass, MP_Node)):
                     if public_parent:
                         obj.parent_id = public_parent.pk
                         obj.parent = public_parent
-                        obj.add_root(instance=obj)
-                        obj = obj.reload()
+                        obj = obj.add_root(instance=obj)
                         obj = obj.move(target=public_parent, pos='first-child')
         else:
             # check if object was moved / structural tree change

--- a/cms/tests/page.py
+++ b/cms/tests/page.py
@@ -675,7 +675,7 @@ class PagesTestCase(CMSTestCase):
             position=1,
             language=settings.LANGUAGES[0][0]
         )
-        plugin_base.add_root(instance=plugin_base)
+        plugin_base = plugin_base.add_root(instance=plugin_base)
 
         plugin = Text(body='')
         plugin_base.set_base_attr(plugin)

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -742,8 +742,7 @@ class PluginsTestCase(PluginsTestBaseCase):
             placeholder=placeholder,
             position=0,
             language=self.FIRST_LANG)
-        plugin_base.add_root(instance=plugin_base)
-        plugin_base = CMSPlugin.objects.get(pk=plugin_base.pk)
+        plugin_base = plugin_base.add_root(instance=plugin_base)
         plugin = Text(body='')
         plugin_base.set_base_attr(plugin)
         plugin.save()
@@ -753,15 +752,13 @@ class PluginsTestCase(PluginsTestBaseCase):
             placeholder=placeholder,
             position=0,
             language=self.FIRST_LANG)
-        plugin_base.add_child(instance=plugin_ref_1_base)
-        plugin_ref_1_base = CMSPlugin.objects.get(pk=plugin_ref_1_base.pk)
+        plugin_ref_1_base = plugin_base.add_child(instance=plugin_ref_1_base)
         plugin_ref_2_base = CMSPlugin(
             plugin_type='TextPlugin',
             placeholder=placeholder,
             position=1,
             language=self.FIRST_LANG)
-        plugin_base.add_child(instance=plugin_ref_2_base)
-        plugin_ref_2_base = CMSPlugin.objects.get(pk=plugin_ref_2_base.pk)
+        plugin_ref_2_base = plugin_base.add_child(instance=plugin_ref_2_base)
         plugin_ref_2 = Text(body='')
         plugin_ref_2_base.set_base_attr(plugin_ref_2)
 


### PR DESCRIPTION
Treebeard returns the created objects in add_*() calls. By using these returns values consistently, we can save unnecessary db hits since calling `reload()` etc in some cases is no longer needed. We also get the benefit of knowing the object has the appropriate and latest path/depth/numChild values from treebeard to avoid hard to debug tree corruption errors.

Refs #3820 and refs #3826